### PR TITLE
ci: skip release-please job when secret is not defined

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,7 +10,16 @@ permissions:
 name: release-please
 
 jobs:
+  check-secret:
+    runs-on: ubuntu-latest
+    outputs:
+      has-token: ${{ steps.check.outputs.has-token }}
+    steps:
+      - id: check
+        run: echo "has-token=${{ secrets.RELEASE_PLEASE_TOKEN_PROVIDER_PEM != '' }}" >> $GITHUB_OUTPUT
   release-please:
+    needs: check-secret
+    if: needs.check-secret.outputs.has-token == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App token


### PR DESCRIPTION
The release-please workflow fails in forks or environments where `RELEASE_PLEASE_TOKEN_PROVIDER_PEM` is not configured, erroring at the GitHub App token generation step.

## Changes

Added a `check-secret` job that checks whether the secret is available (since `secrets` context isn't accessible at the job-level `if`), and gates the `release-please` job with `needs` + `if`.